### PR TITLE
docs: fix simple typo, chech -> check

### DIFF
--- a/pyredise/corpus_handler.py
+++ b/pyredise/corpus_handler.py
@@ -149,7 +149,7 @@ class CorpusHandler(index_handler.IndexHandler):
         rnd = kwargs.get('rnd', 4)
         doc = kwargs.get('doc', None)
 
-        # just in case, we chech if we have to re-tokenize the doc
+        # just in case, we check if we have to re-tokenize the doc
         if not len(self.sanitized_text):
             if doc is None: 
                 raise Exception, " No document given !! "


### PR DESCRIPTION
There is a small typo in pyredise/corpus_handler.py.

Should read `check` rather than `chech`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md